### PR TITLE
Buffs Mechs to be more relevant with current weapon damage values

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	step_in = 4
 	health = 500
 	deflect_chance = 20
-	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.75,"energy"=0.9,"bomb"=0.75)
+	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.70,"energy"=0.9,"bomb"=0.75)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	step_in = 4
 	health = 500
 	deflect_chance = 20
-	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.75,"energy"=0.9,"bomb"=0.8)
+	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.75,"energy"=0.9,"bomb"=0.75)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	step_in = 4
 	health = 500
 	deflect_chance = 20
-	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.70,"energy"=0.9,"bomb"=0.75)
+	damage_absorption = list("brute"=0.5,"fire"=1,"bullet"=0.5,"laser"=0.7,"energy"=0.9,"bomb"=0.75)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -4,9 +4,9 @@
 	icon_state = "durand"
 	initial_icon = "durand"
 	step_in = 4
-	health = 400
+	health = 500
 	deflect_chance = 20
-	damage_absorption = list("brute"=0.5,"fire"=1.1,"bullet"=0.65,"laser"=0.85,"energy"=0.9,"bomb"=0.8)
+	damage_absorption = list("brute"=0.5,"fire"=1.0,"bullet"=0.50,"laser"=0.75,"energy"=0.9,"bomb"=0.8)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -5,9 +5,9 @@
 	initial_icon = "gygax"
 	step_in = 3
 	dir_in = 1 //Facing North.
-	health = 300
+	health = 400
 	deflect_chance = 15
-	damage_absorption = list("brute"=0.75,"fire"=1,"bullet"=0.8,"laser"=0.7,"energy"=0.85,"bomb"=1)
+	damage_absorption = list("brute"=0.60,"fire"=1,"bullet"=0.65,"laser"=0.5,"energy"=0.85,"bomb"=1)
 	max_temperature = 25000
 	infra_luminosity = 6
 	var/overload = 0
@@ -21,9 +21,9 @@
 	name = "Dark Gygax"
 	icon_state = "darkgygax"
 	initial_icon = "darkgygax"
-	health = 400
+	health = 500
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.6,"fire"=0.8,"bullet"=0.6,"laser"=0.5,"energy"=0.65,"bomb"=0.8)
+	damage_absorption = list("brute"=0.55,"fire"=0.8,"bullet"=0.55,"laser"=0.4,"energy"=0.65,"bomb"=0.8)
 	max_temperature = 45000
 	overload_coeff = 1
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/dark

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -7,7 +7,7 @@
 	dir_in = 1 //Facing North.
 	health = 400
 	deflect_chance = 15
-	damage_absorption = list("brute"=0.60,"fire"=1,"bullet"=0.65,"laser"=0.5,"energy"=0.85,"bomb"=0.85)
+	damage_absorption = list("brute"=0.6,"fire"=1,"bullet"=0.7,"laser"=0.65,"energy"=0.85,"bomb"=0.85)
 	max_temperature = 25000
 	infra_luminosity = 6
 	var/overload = 0

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -7,7 +7,7 @@
 	dir_in = 1 //Facing North.
 	health = 400
 	deflect_chance = 15
-	damage_absorption = list("brute"=0.60,"fire"=1,"bullet"=0.65,"laser"=0.5,"energy"=0.85,"bomb"=1)
+	damage_absorption = list("brute"=0.60,"fire"=1,"bullet"=0.65,"laser"=0.5,"energy"=0.85,"bomb"=0.85)
 	max_temperature = 25000
 	infra_luminosity = 6
 	var/overload = 0
@@ -23,7 +23,7 @@
 	initial_icon = "darkgygax"
 	health = 500
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.55,"fire"=0.8,"bullet"=0.55,"laser"=0.4,"energy"=0.65,"bomb"=0.8)
+	damage_absorption = list("brute"=0.55,"fire"=0.8,"bullet"=0.55,"laser"=0.4,"energy"=0.65,"bomb"=0.75)
 	max_temperature = 45000
 	overload_coeff = 1
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/dark

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -4,9 +4,9 @@
 	icon_state = "marauder"
 	initial_icon = "marauder"
 	step_in = 5
-	health = 500
+	health = 600
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.5,"fire"=0.7,"bullet"=0.45,"laser"=0.6,"energy"=0.7,"bomb"=0.7)
+	damage_absorption = list("brute"=0.4,"fire"=0.6,"bullet"=0.40,"laser"=0.50,"energy"=0.7,"bomb"=0.5)
 	max_temperature = 60000
 	infra_luminosity = 3
 	var/zoom = 0
@@ -29,7 +29,7 @@
 	initial_icon = "seraph"
 	operation_req_access = list(access_cent_creed)
 	step_in = 3
-	health = 550
+	health = 750
 	wreckage = /obj/effect/decal/mecha_wreckage/seraph
 	internal_damage_threshold = 20
 	force = 55

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -6,7 +6,7 @@
 	step_in = 5
 	health = 600
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.4,"fire"=0.6,"bullet"=0.40,"laser"=0.50,"energy"=0.7,"bomb"=0.5)
+	damage_absorption = list("brute"=0.4,"fire"=0.6,"bullet"=0.4,"laser"=0.5,"energy"=0.7,"bomb"=0.5)
 	max_temperature = 60000
 	infra_luminosity = 3
 	var/zoom = 0

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -6,16 +6,16 @@
 	step_in = 1
 	dir_in = 1 //Facing North.
 	step_energy_drain = 100
-	health = 200
+	health = 250
 	deflect_chance = 30
-	damage_absorption = list("brute"=0.7,"fire"=0.7,"bullet"=0.7,"laser"=0.7,"energy"=0.7,"bomb"=0.7)
+	damage_absorption = list("brute"=0.6,"fire"=0.7,"bullet"=0.6,"laser"=0.6,"energy"=0.6,"bomb"=0.6)
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/effect/decal/mecha_wreckage/phazon
 	add_req_access = 1
 	//operation_req_access = list()
 	internal_damage_threshold = 25
-	force = 15
+	force = 20
 	var/phasing = 0
 	var/phasing_energy_drain = 5 KILOWATTS
 	max_equip = 4

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -39,7 +39,7 @@
 	var/mhit_power_use = 0
 
 	//the values in this list show how much damage will pass through, not how much will be absorbed.
-	var/list/damage_absorption = list("brute"=0.8,"fire"=1.2,"bullet"=0.9,"laser"=1,"energy"=1,"bomb"=1)
+	var/list/damage_absorption = list("brute"=0.7,"fire"=1.2,"bullet"=0.9,"laser"=0.8,"energy"=1,"bomb"=0.9)
 	var/obj/item/cell/cell
 	var/state = 0
 	var/list/log = new

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -1,5 +1,5 @@
 /obj/mecha/medical/odysseus
-	desc = "These exosuits are developed and produced by Vey-Med. (&copy; All rights reserved)."
+	desc = "A medical exosuit commonly used to retrieve critcally injured patients in hazardous situations. It's lack of armour and inability to mount weapons systems makes it inadvisable to use on the front lines, however."
 	name = "Odysseus"
 	icon_state = "odysseus"
 	initial_icon = "odysseus"
@@ -7,7 +7,7 @@
 	max_temperature = 15000
 	health = 200
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus
-	internal_damage_threshold = 35
+	internal_damage_threshold = 30
 	deflect_chance = 15
 	var/obj/item/clothing/glasses/hud/health/mech/hud
 

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -9,6 +9,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus
 	internal_damage_threshold = 30
 	deflect_chance = 15
+	max_equip = 4
 	var/obj/item/clothing/glasses/hud/health/mech/hud
 
 	New()

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -5,7 +5,7 @@
 	initial_icon = "odysseus"
 	step_in = 2
 	max_temperature = 15000
-	health = 120
+	health = 200
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus
 	internal_damage_threshold = 35
 	deflect_chance = 15

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -8,6 +8,7 @@
 	health = 250
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10
+	max_equip = 4
 
 /obj/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in src.cargo)

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -3,9 +3,9 @@
 	name = "APLU \"Ripley\""
 	icon_state = "ripley"
 	initial_icon = "ripley"
-	step_in = 6
+	step_in = 4 // no reason to be slower then a Durand
 	max_temperature = 20000
-	health = 200
+	health = 250
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10
 
@@ -25,9 +25,9 @@
 	icon_state = "firefighter"
 	initial_icon = "firefighter"
 	max_temperature = 65000
-	health = 250
+	health = 300
 	lights_power = 8
-	damage_absorption = list("fire"=0.5,"bullet"=0.8,"bomb"=0.5)
+	damage_absorption = list("fire"=0.5,"bullet"=0.75,"laser"=0.6,"bomb"=0.5)
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/firefighter
 
 /obj/mecha/working/ripley/deathripley


### PR DESCRIPTION
This simply buffs Mech's health and armor values so they're not completely worthless in combat. I thought this was worth putting out here as the standard Lasgun which everyone carries can currently put down a Gygax 10-15 hits which is fairly 'meh' especially at higher population.

This shouldn't be OP; Mechs still require a decent amount of effort in RnD/Materials, have limited power and are clunky and slow enough to be overwhelmed if they're out alone. Also increases the equipment slots of the Odysseus and Ripley.

tl;dr version: Assuming we're using basic 40 damage lasguns, 

buffs the Durand from ~15 hits to kill (HtK) to about ~20 HtK

buffs the Gygax from ~12 HtK to about ~15 HtK

buffs the Phazon (Probably can't be built at this point) from ~12 Htk to around ~15ish. 

buffs the Ripley, Firefighter and Odysseus so they don't crumple from two or three rounds. You'll still likely lose to a naked guy with a lasgun, however.

Shouldn't be any bugs as I've only changed health/resistance values unless I mistyped something.
