### PR TITLE
nerfs, buffs, and lore

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -23,7 +23,7 @@
 	icon = 'icons/obj/grenade.dmi'
 
 	var/list/fragment_types = list(/obj/item/projectile/bullet/pellet/fragment = 1)
-	var/num_fragments = 72  //total number of fragments produced by the grenade
+	var/num_fragments = 18  //total number of fragments produced by the grenade (nerfed by x4. 72 / 4 = 18 let's see if this is too little -plinypotter)
 	var/explosion_size = 2   //size of the center explosion
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
@@ -158,7 +158,7 @@ obj/mortar/flare/blue
 	desc = "A light fragmentation grenade, designed to be fired from a launcher. It can still be activated and thrown by hand if necessary."
 	icon_state = "fragshell"
 
-	num_fragments = 50 //less powerful than a regular frag grenade
+	num_fragments = 12 //less powerful than a regular frag grenade (nerfed by x4. 50 / 4 = 12, let's see if this helps lag -plinypotter)
 
 
 /obj/item/grenade/frag/high_yield
@@ -171,7 +171,7 @@ obj/mortar/flare/blue
 	throw_range = 5 //heavy, can't be thrown as far
 
 	fragment_types = list(/obj/item/projectile/bullet/pellet/fragment=1,/obj/item/projectile/bullet/pellet/fragment/strong=4)
-	num_fragments = 200  //total number of fragments produced by the grenade
+	num_fragments = 50  //total number of fragments produced by the grenade (nerfed by x4. 200 / 4 = 50 -plinypotter)
 	explosion_size = 3
 
 /obj/item/grenade/frag/high_yield/on_explosion(var/turf/O)
@@ -180,9 +180,9 @@ obj/mortar/flare/blue
 
 /obj/item/grenade/frag/high_yield/krak
 	name = "Krak Grenade"
-	desc = "A potent anti armor grenade used by the Imperium of Man, mind the blast radius, its weight makes it harder to throw."
+	desc = "A potent anti armor grenade used by the Imperium of Man, mind the blast radius."
 	icon_state = "krak_grenade"
-	num_fragments = 250
+	num_fragments = 40 // nerfed by x6. 250 / 6 = 41 i rounded it to 40. let's see if this helps lag - plinypotter
 	explosion_size = 4
 
 /obj/item/grenade/frag/high_yield/krak/prime()

--- a/code/modules/mob/living/carbon/human/species/races/orks/abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/races/orks/abilities.dm
@@ -43,11 +43,11 @@
 	if(waaagh >= 100 && !cooldown)
 		visible_message("<span class='notice'>The [src] starts healing rapidly in front of your eyes.</span>", "<span class='notice'>You heal rapidly.</span>")
 		playsound(src, 'sound/voice/ork/orkscream.ogg', 50, 5)
-		adjustBruteLoss(-10)
-		adjustFireLoss(-10)
-		adjustOxyLoss(-10)
-		adjustToxLoss(-10)
-		adjustBrainLoss(-10)
+		adjustBruteLoss(-5)
+		adjustFireLoss(-5)
+		adjustOxyLoss(-5)
+		adjustToxLoss(-5)
+		adjustBrainLoss(-5)
 		restore_all_organs()
 		src.radiation = 0
 		src.bodytemperature = T20C
@@ -60,7 +60,7 @@
 		src.ear_damage = 0
 		src.inject_blood(src, 200)
 		cooldown = TRUE
-		spawn(50)
+		spawn(120)
 			cooldown = FALSE
 		waaagh -= 100
 	else

--- a/code/modules/mob/living/carbon/human/species/races/orks/ork_species.dm
+++ b/code/modules/mob/living/carbon/human/species/races/orks/ork_species.dm
@@ -44,12 +44,12 @@
 
 /mob/living/carbon/human/ork/Life()
 	..()
-	var/regen = 0.5
+	var/regen = 0.25
 	if(max_waaagh > 0)
 		if(inspired)
-			regen = 2
+			regen = 1
 		else
-			regen = 0.5
+			regen = 0.25
 
 		waaagh = max(0, min(waaagh + regen, max_waaagh))
 

--- a/code/modules/mob/living/carbon/human/species/races/tau.dm
+++ b/code/modules/mob/living/carbon/human/species/races/tau.dm
@@ -10,7 +10,7 @@
 	min_age = 50
 	max_age = 800
 	gluttonous = GLUT_ITEM_NORMAL
-	total_health = 250
+	total_health = 150
 	mob_size = MOB_MEDIUM
 	strength = STR_MEDIUM
 	sexybits_location = BP_GROIN
@@ -80,8 +80,8 @@
 			equip_to_slot_or_del(new /obj/item/gun/energy/pulse/pulsepistol, slot_in_backpack)
 
 			visible_message("[name] stretches their muscles after a long flight, feeling their strength and skill return to them.")
-			src.add_stats(rand(14,16),rand(14,18),rand(12,15),10) //gives stats str, end, int, dex
-			src.add_skills(rand(6,10),rand(6,10),rand(0,3),0,0) //skills such as melee, ranged, med, eng and surg
+			src.add_stats(rand(10,12),rand(14,18),rand(12,15),10) //gives stats str, end, int, dex
+			src.add_skills(rand(4,9),rand(8,13),rand(0,3),0,0) //skills such as melee, ranged, med, eng and surg
 			src.update_eyes() //should fix grey vision
 			src.warfare_language_shit(TAU) //secondary language
 			src.name = "Shas [name]"
@@ -110,7 +110,7 @@
 			equip_to_slot_or_del(new /obj/item/clothing/suit/watercaste, slot_wear_suit)
 
 			visible_message("[name] stretches their muscles after a long flight, feeling their strength and skill return to them.")
-			src.add_stats(rand(10,12),rand(10,12),rand(12,13),15) //gives stats str, end, int, dex
+			src.add_stats(rand(6,8),rand(10,12),rand(12,13),15) //gives stats str, end, int, dex
 			src.add_skills(rand(3,6),rand(3,6),rand(0,3),3,3) //skills such as melee, ranged, med, eng and surg
 			src.update_eyes() //should fix grey vision
 			src.warfare_language_shit(TAU) //secondary language

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -236,6 +236,13 @@ obj/item/gun/energy/retro
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    one_hand_penalty=3, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.6, 1.0), automatic = 0),
 		)
 
+/obj/item/gun/energy/las/lasgun/lascarbine
+	name = "lascarbine"
+	desc = "A modified version of the standard-issue rifle. It costs more to shoot, but it's easy to carry and can be shot easier with one hand. Given to scout units of the Astra Militarum."
+	one_hand_penalty = 1
+	charge_cost = 70
+	w_class = ITEM_SIZE_NORMAL
+
 /obj/item/gun/energy/las/lasgun/luscius
 	name = "lucius pattern lasgun"
 	desc = "The standard-issue rifle of the Death Korps of Krieg."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -366,7 +366,7 @@
 	force = 10
 	max_shells = 50
 	caliber = ".75"
-	condition = 40
+	condition = 60
 	ammo_type = /obj/item/ammo_casing/ork/shoota
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/ork/shoota

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -73,6 +73,10 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	jammed_icon = "talon-j"
 
+/obj/item/gun/projectile/talon/adept
+	name = "dulled stub pistol"
+	desc = "A slightly dulled, worn out, stub-pistol. Beaten down from the days spent sitting in a desk drawer. It has the sigil of the Adeptus Administratum on it."
+
 /obj/item/gun/projectile/talon/update_icon()
 	..()
 	if(!is_jammed)
@@ -329,6 +333,6 @@
 	allowed_magazines = /obj/item/ammo_magazine/ork/slugga
 	icon_state = "slugga"
 	caliber = ".75"
-	condition = 40
+	condition = 60
 	force = 20
 	load_method = MAGAZINE

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -546,7 +546,7 @@ Begin Warhammer loadouts
 			/mob/living/carbon/human/proc/khorne,
 			/mob/living/carbon/human/proc/nurgle,
 			/mob/living/carbon/human/proc/slaanesh,
-			/mob/living/carbon/human/proc/tzeentch)
+			/mob/living/carbon/human/proc/tzeentch) //kriegers by lore are unable to be heretics or so says krieger young woman on discord.
 
 			var/obj/item/card/id/dog_tag/guardsman/W = new
 

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -546,7 +546,11 @@ Begin Warhammer loadouts
 			/mob/living/carbon/human/proc/khorne,
 			/mob/living/carbon/human/proc/nurgle,
 			/mob/living/carbon/human/proc/slaanesh,
-			/mob/living/carbon/human/proc/tzeentch) //kriegers by lore are unable to be heretics or so says krieger young woman on discord.
+			/mob/living/carbon/human/proc/tzeentch)
+			src.rage = null
+			src.lust = null
+			src.decay = null
+			src.intrigue = null //kriegers by lore are unable to be heretics or so says krieger young woman on discord.
 
 			var/obj/item/card/id/dog_tag/guardsman/W = new
 

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -541,7 +541,12 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
 			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
 			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
-			U.verbs -= list(/mob/living/carbon/human/proc/regimentselection,)
+			U.verbs -= list(
+			/mob/living/carbon/human/proc/regimentselection,
+			/mob/living/carbon/human/proc/khorne,
+			/mob/living/carbon/human/proc/nurgle,
+			/mob/living/carbon/human/proc/slaanesh,
+			/mob/living/carbon/human/proc/tzeentch)
 
 			var/obj/item/card/id/dog_tag/guardsman/W = new
 

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -582,7 +582,7 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/lascarbine, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/device/flashlight/lantern, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)

--- a/maps/delta/jobs/pilgrims.dm
+++ b/maps/delta/jobs/pilgrims.dm
@@ -293,6 +293,8 @@ Pilgrim Fate System
 	/obj/item/stack/thrones = 2,
 	/obj/item/stack/thrones2/five = 1,
 	/obj/item/stack/thrones3/twenty = 1,
+	/obj/item/gun/projectile/talon/adept = 1,
+	/obj/item/ammo_magazine/c45m = 2,
 
 	)
 	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR


### PR DESCRIPTION
- Nerfs Orks at the request of many. They should be more manageable now, hopefully. In addition I've increased the quality of their guns so they shouldn't jam all the time, more lore compliant.
- Nerfs fragmentation grenades and kraks at the request of staff and to hopefully curb them lagging the server when they're thrown.
- Nerfs Tau because of a [suggestion made by KalashVodka](https://discord.com/channels/749494471737212949/758112267509563422/876529413506875482) they are weaker in close ranged combat but stronger at ranged combat.
- Adds a stub-pistol to the Administratum Adept because of a [suggestion made by Thood74](https://discord.com/channels/749494471737212949/758112267509563422/876521156159615006)
- Creates and adds a lascarbine to the Catachans because of a [suggestion made by El Doofer](https://discord.com/channels/749494471737212949/758112267509563422/875406762726023189). Lascarbines have less of a harsh one-hand penalty, can be stowed easier, but cost more to shoot.
- Removes the ability for Kriegers to be heretics because of a suggestion made by Krieger Young Woman, and for lore reasons.

let's see how this goes, good thing we've got a big pool to test it for us