### PR TITLE
Imperial Guard Loadout Change Ft. Little bit of extra stuff

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -135,7 +135,7 @@
 
 /decl/hierarchy/outfit/job/medical/paramedic
 	name = OUTFIT_JOB_NAME("combat medicae")
-	uniform = /obj/item/clothing/under/guard/uniform
+	uniform = /obj/item/clothing/under/cadian_uniform
 	suit = /obj/item/clothing/suit/armor/medicae
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/thick/swat/combat/warfare

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -135,7 +135,7 @@
 
 /decl/hierarchy/outfit/job/medical/paramedic
 	name = OUTFIT_JOB_NAME("combat medicae")
-	uniform = /obj/item/clothing/under/rank/medical/scrubs/black
+	uniform = /obj/item/clothing/under/guard/uniform
 	suit = /obj/item/clothing/suit/armor/medicae
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/thick/swat/combat/warfare
@@ -143,11 +143,13 @@
 	neck = /obj/item/reagent_containers/food/drinks/canteen
 	belt = /obj/item/storage/belt/medical/full
 	head = /obj/item/clothing/head/helmet/medicae
+	r_pocket = /obj/item/storage/box/ifak
+	l_pocket = /obj/item/cell/lasgun
 	id_type = /obj/item/card/id/medical/paramedic
 	l_ear = null
 	r_ear = null
 	backpack_contents = list(
-	/obj/item/cell/lasgun = 2,
+	/obj/item/cell/lasgun = 1,
 	/obj/item/reagent_containers/food/snacks/warfare/rat = 1,
 	/obj/item/stack/thrones = 1,
 	/obj/item/stack/thrones2 = 1,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -403,10 +403,40 @@
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
-/obj/item/clothing/suit/armor/sgt
-	name = "Guard Sergeant's Armor"
-	desc = "The well-worn armor of an Imperial Guard Sergeant."
+/obj/item/clothing/suit/armor/cadiansgt
+	name = "Cadian Sergeant's Armor"
+	desc = "The well-worn armor of an Cadian Regiment Sergeant."
 	icon_state = "fharmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 20, bio = 10, rad = 0)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/catachansgt
+	name = "Catachan Sergeant's Vest"
+	desc = "Flak vests worn by renowned Catachan Sergeant."
+	icon_state = "Catachan_Vest"
+	item_state = "Catachan_Vest"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 20, bio = 10, rad = 0)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/valhallasgt
+	name = "valhallan Sergeant's Greatcoat"
+	desc = "An veteran sergeant's coat, worn but glorious."
+	icon_state = "valarmor"
+	item_state = "valarmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 20, bio = 10, rad = 0)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/kriegsgt
+	name = "Krieg Sergeant's Battlecoat"
+	desc = "Ornated in red waffenfarbe and silverish lining, the Battlecoat represent veterancy and status. Worn by only the Krieg's fearless sergeant."
+	icon_state = "kriegcoat"
+	item_state = "kriegcoat"
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
 	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 20, bio = 10, rad = 0)
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS

--- a/code/modules/clothing/under/casual_pants.dm
+++ b/code/modules/clothing/under/casual_pants.dm
@@ -100,3 +100,10 @@
 	name = "baggy camo pants"
 	desc = "A pair of woodland camouflage pants. Probably not the best choice for space."
 	icon_state = "baggy_camopants"
+
+// Catachan Pants
+
+/obj/item/clothing/under/casual_pants/catachan
+	name = "Catachan Battle Shorts"
+	desc = "Catachan fear no temperature, no bullet, they don't need shirt, They're Catachan Regiment."
+	icon_state = "camopants"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -207,9 +207,9 @@
 	item_state = "ba_suit"
 	worn_state = "barny"
 
-/obj/item/clothing/under/rank/krieger
-	name = "krieg fatigues"
-	desc = "It's made of a slightly sturdier material than standard jumpsuits, to allow for robust protection."
+/obj/item/clothing/under/rank/krieg_uniform
+	name = "krieg Battle Uniform"
+	desc = "These durable Battle Uniform are used to represent the resilent Krieg Regiment."
 	icon_state = "krieg"
 	item_state = "krieg"
 	worn_state = "krieg"
@@ -218,10 +218,21 @@
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
-/obj/item/clothing/under/guard_uniform
-	name = "Imperial Guard uniform"
-	desc = "The uniform of those who fight in His name."
+/obj/item/clothing/under/cadian_uniform
+	name = "Cadian Battle Dress Uniform"
+	desc = "The uniform of the brave Cadian Regiment."
 	icon_state = "guard_s"
 	item_state = "guard"
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/under/rank/valhallan_uniform
+	name = "Valhalla Battle Uniform"
+	desc = "The uniform made out of their planetary predator's furs, Durable and warm, Made for the cold warriors of Valhalla Regiment."
+	icon_state = "krieg"
+	item_state = "krieg"
+	worn_state = "krieg"
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 0.9
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -86,7 +86,8 @@
 		/mob/living/carbon/human/proc/khorne,
 		/mob/living/carbon/human/proc/nurgle,
 		/mob/living/carbon/human/proc/slaanesh,
-		/mob/living/carbon/human/proc/tzeentch)
+		/mob/living/carbon/human/proc/tzeentch
+		/mob/living/carbon/human/proc/sergeantselection,)
 
 
 /datum/job/ig/commissar
@@ -194,9 +195,7 @@
 	can_be_in_squad = FALSE
 	open_when_dead = TRUE
 	department_flag = SEC
-
 	announced = FALSE
-
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
@@ -309,116 +308,6 @@ Begin Warhammer loadouts
 	)
 
 	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
-/decl/hierarchy/outfit/job/redsoldier/engineer
-	r_pocket = /obj/item/ammo_magazine/mc9mmt/machinepistol
-	l_pocket = /obj/item/wirecutters
-	suit_store = /obj/item/gun/projectile/automatic/machinepistol/wooden
-	back = /obj/item/storage/backpack/warfare
-	backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/shovel = 1, /obj/item/defensive_barrier = 4, /obj/item/storage/box/ifak = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/engineer/equip()
-	if(prob(1))//Rare engineer spawn
-		suit_store = /obj/item/gun/projectile/automatic/autoshotty
-		r_pocket = /obj/item/shovel
-		belt = /obj/item/storage/belt/autoshotty
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-	else if(prob(50))
-		suit_store = /obj/item/gun/projectile/shotgun/pump/shitty
-		r_pocket = /obj/item/ammo_box/shotgun
-		belt = /obj/item/shovel
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-	else
-		suit_store = /obj/item/gun/projectile/automatic/machinepistol
-		r_pocket = /obj/item/shovel
-		belt = /obj/item/storage/belt/warfare
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-
-/decl/hierarchy/outfit/job/redsoldier/sentry
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/armor/sentry/red
-	head = /obj/item/clothing/head/legacy/sentryhelm/red
-	belt = /obj/item/melee/trench_axe
-	suit_store = /obj/item/gun/projectile/automatic/mg08
-	backpack_contents = list(/obj/item/ammo_magazine/box/a556/mg08 = 3, /obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sentry/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/flamer
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/fire/red
-	head = /obj/item/clothing/head/legacy/redhelmet/fire
-	belt = /obj/item/gun/projectile/automatic/flamer
-	suit_store = /obj/item/melee/trench_axe
-	r_pocket = /obj/item/grenade/fire
-	backpack_contents = list(/obj/item/ammo_magazine/flamer = 4, /obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sniper
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/armor/redcoat/sniper
-	head = /obj/item/clothing/head/helmet/redhelmet/sniper
-	suit_store = /obj/item/gun/projectile/heavysniper
-	belt = /obj/item/gun/projectile/revolver //Backup weapon.
-	r_pocket = /obj/item/ammo_box/ptsd
-	backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sniper/equip()
-	if(prob(50))
-		belt = /obj/item/gun/projectile/warfare
-	else
-		belt = /obj/item/gun/projectile/revolver
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/medic
-	belt = /obj/item/storage/belt/medical/full
-	r_pocket = /obj/item/ammo_magazine/c45rifle/akarabiner
-	l_pocket = /obj/item/stack/medical/bruise_pack
-	suit_store = /obj/item/gun/projectile/automatic/m22/warmonger
-	gloves = /obj/item/clothing/gloves/latex
-	head = /obj/item/clothing/head/helmet/redhelmet/medic
-
-/decl/hierarchy/outfit/job/redsoldier/medic/equip()
-	if(prob(50))
-		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger
-		r_pocket = /obj/item/ammo_magazine/c45rifle/akarabiner
-		backpack_contents = list( /obj/item/ammo_magazine/c45rifle/akarabiner = 3, /obj/item/grenade/smokebomb = 1)
-
-	else
-		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty
-		r_pocket = /obj/item/ammo_box/rifle
-		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/leader/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1 , /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/scout
-	suit = /obj/item/clothing/suit/child_coat/red
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	uniform = /obj/item/clothing/under/child_jumpsuit/warfare
-	shoes = /obj/item/clothing/shoes/child_shoes
-	gloves = null
-	r_pocket = /obj/item/device/binoculars
-	backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-
-
-/decl/hierarchy/outfit/job/redsoldier/scout/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1 , /obj/item/torch/self_lit = 1)
-	..()
 
 /decl/hierarchy/outfit/job/kroot
 	uniform = /obj/item/clothing/under/rank/kroot
@@ -504,6 +393,8 @@ Begin Warhammer loadouts
 	id_slot = null
 	pda_slot = null
 	backpack_contents = list(/obj/item/reagent_containers/food/snacks/warfare/rat = 1,)
+
+/// TROOPER REGIMENT SELECTION
 
 /mob/living/carbon/human/proc/regimentselection()
 	set name = "Select your regiment"
@@ -625,6 +516,131 @@ Begin Warhammer loadouts
 
 			W.icon_state = "tagred"
 			W.assignment = "Valhallan"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+/// SERGEANT REGIMENT SELECTION
+
+/mob/living/carbon/human/proc/sergeantselection()
+	set name = "Select your regiment"
+	set category = "Regimental Sergeant Position"
+	set desc = "Choose your regiment"
+	if(!ishuman(src))
+		to_chat(src, "<span class='notice'>How tf are you seeing this, ping Wel Ard immediately</span>")
+		return
+	if(src.stat == DEAD)
+		to_chat(src, "<span class='notice'>You can't choose a class when you're dead.</span>")
+		return
+	var/mob/living/carbon/human/U = src
+	var/chapter = list("Cadian", "Krieger", "Catachan", "Valhallan") //lists all possible chapters
+	var/chapterchoice = input("Choose your regiment", "Available regiments") as anything in chapter
+
+	switch(chapterchoice)
+		if("Krieger")
+			var/troopnum = rand(1,50000)
+			src.name = "Troop [troopnum]"
+			src.real_name = "Troop [troopnum]"
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/krieger, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/mask/gas/krieg, slot_wear_mask)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/krieghelmet, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/krieg, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/shovel, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(
+			/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Krieg Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+		if("Cadian")
+			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Cadian Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+		if("Catachan")
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/device/flashlight/lantern, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Catachan Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+		if("Valhallan")
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/lascarbine, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Valhallan Sergeant"
 			W.registered_name = real_name
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)

--- a/maps/delta/jobs/guardsmen.dm
+++ b/maps/delta/jobs/guardsmen.dm
@@ -258,8 +258,8 @@ Begin Warhammer loadouts
 /decl/hierarchy/outfit/job/ig/sergeant
 	name = OUTFIT_JOB_NAME("Imperial Guard Sergeant")
 	neck = /obj/item/reagent_containers/food/drinks/canteen
-	uniform = /obj/item/clothing/under/color/brown
-	suit = /obj/item/clothing/suit/armor/sgt
+	uniform = /obj/item/clothing/under/cadian_uniform
+	suit = /obj/item/clothing/suit/armor/cadiansgt
 	glasses = /obj/item/clothing/glasses/sunglasses
 	suit_store = /obj/item/gun/projectile/automatic/stubber
 	head = /obj/item/clothing/head/helmet/guardhelmet
@@ -415,7 +415,7 @@ Begin Warhammer loadouts
 			var/troopnum = rand(1,50000)
 			src.name = "Troop [troopnum]"
 			src.real_name = "Troop [troopnum]"
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieg_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
 			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
@@ -444,7 +444,7 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Cadian")
-			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/cadian_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -470,7 +470,7 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Catachan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/catachan, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -495,7 +495,7 @@ Begin Warhammer loadouts
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)
 		if("Valhallan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/valhallan_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -541,9 +541,8 @@ Begin Warhammer loadouts
 			var/troopnum = rand(1,50000)
 			src.name = "Troop [troopnum]"
 			src.real_name = "Troop [troopnum]"
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieg_uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/kriegsgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/krieger, slot_back)
 			equip_to_slot_or_del(new /obj/item/clothing/mask/gas/krieg, slot_wear_mask)
@@ -569,11 +568,10 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Cadian")
-			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/under/cadian_uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/cadiansgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
@@ -595,11 +593,10 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Catachan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/catachan, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/catachansgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/device/flashlight/lantern, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
@@ -620,11 +617,10 @@ Begin Warhammer loadouts
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)
 		if("Valhallan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/valhallan_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallasgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/lascarbine, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)

--- a/maps/warhammer/jobs/guardsmen.dm
+++ b/maps/warhammer/jobs/guardsmen.dm
@@ -86,7 +86,8 @@
 		/mob/living/carbon/human/proc/khorne,
 		/mob/living/carbon/human/proc/nurgle,
 		/mob/living/carbon/human/proc/slaanesh,
-		/mob/living/carbon/human/proc/tzeentch)
+		/mob/living/carbon/human/proc/tzeentch
+		/mob/living/carbon/human/proc/sergeantselection,)
 
 
 /datum/job/ig/commissar
@@ -194,9 +195,7 @@
 	can_be_in_squad = FALSE
 	open_when_dead = TRUE
 	department_flag = SEC
-
 	announced = FALSE
-
 	equip(var/mob/living/carbon/human/H)
 		var/current_name = H.real_name
 		..()
@@ -309,116 +308,6 @@ Begin Warhammer loadouts
 	)
 
 	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
-/decl/hierarchy/outfit/job/redsoldier/engineer
-	r_pocket = /obj/item/ammo_magazine/mc9mmt/machinepistol
-	l_pocket = /obj/item/wirecutters
-	suit_store = /obj/item/gun/projectile/automatic/machinepistol/wooden
-	back = /obj/item/storage/backpack/warfare
-	backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/shovel = 1, /obj/item/defensive_barrier = 4, /obj/item/storage/box/ifak = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/engineer/equip()
-	if(prob(1))//Rare engineer spawn
-		suit_store = /obj/item/gun/projectile/automatic/autoshotty
-		r_pocket = /obj/item/shovel
-		belt = /obj/item/storage/belt/autoshotty
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-	else if(prob(50))
-		suit_store = /obj/item/gun/projectile/shotgun/pump/shitty
-		r_pocket = /obj/item/ammo_box/shotgun
-		belt = /obj/item/shovel
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-	else
-		suit_store = /obj/item/gun/projectile/automatic/machinepistol
-		r_pocket = /obj/item/shovel
-		belt = /obj/item/storage/belt/warfare
-		backpack_contents = list(/obj/item/stack/barbwire = 1, /obj/item/defensive_barrier = 3, /obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 1)
-
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-
-/decl/hierarchy/outfit/job/redsoldier/sentry
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/armor/sentry/red
-	head = /obj/item/clothing/head/legacy/sentryhelm/red
-	belt = /obj/item/melee/trench_axe
-	suit_store = /obj/item/gun/projectile/automatic/mg08
-	backpack_contents = list(/obj/item/ammo_magazine/box/a556/mg08 = 3, /obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sentry/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/flamer
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/fire/red
-	head = /obj/item/clothing/head/legacy/redhelmet/fire
-	belt = /obj/item/gun/projectile/automatic/flamer
-	suit_store = /obj/item/melee/trench_axe
-	r_pocket = /obj/item/grenade/fire
-	backpack_contents = list(/obj/item/ammo_magazine/flamer = 4, /obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sniper
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	suit = /obj/item/clothing/suit/armor/redcoat/sniper
-	head = /obj/item/clothing/head/helmet/redhelmet/sniper
-	suit_store = /obj/item/gun/projectile/heavysniper
-	belt = /obj/item/gun/projectile/revolver //Backup weapon.
-	r_pocket = /obj/item/ammo_box/ptsd
-	backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-
-/decl/hierarchy/outfit/job/redsoldier/sniper/equip()
-	if(prob(50))
-		belt = /obj/item/gun/projectile/warfare
-	else
-		belt = /obj/item/gun/projectile/revolver
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/medic
-	belt = /obj/item/storage/belt/medical/full
-	r_pocket = /obj/item/ammo_magazine/c45rifle/akarabiner
-	l_pocket = /obj/item/stack/medical/bruise_pack
-	suit_store = /obj/item/gun/projectile/automatic/m22/warmonger
-	gloves = /obj/item/clothing/gloves/latex
-	head = /obj/item/clothing/head/helmet/redhelmet/medic
-
-/decl/hierarchy/outfit/job/redsoldier/medic/equip()
-	if(prob(50))
-		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger
-		r_pocket = /obj/item/ammo_magazine/c45rifle/akarabiner
-		backpack_contents = list( /obj/item/ammo_magazine/c45rifle/akarabiner = 3, /obj/item/grenade/smokebomb = 1)
-
-	else
-		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty
-		r_pocket = /obj/item/ammo_box/rifle
-		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1, /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/leader/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1 , /obj/item/torch/self_lit = 1)
-	..()
-
-/decl/hierarchy/outfit/job/redsoldier/scout
-	suit = /obj/item/clothing/suit/child_coat/red
-	l_ear = /obj/item/device/radio/headset/red_team/all
-	uniform = /obj/item/clothing/under/child_jumpsuit/warfare
-	shoes = /obj/item/clothing/shoes/child_shoes
-	gloves = null
-	r_pocket = /obj/item/device/binoculars
-	backpack_contents = list(/obj/item/grenade/smokebomb = 1)
-
-
-/decl/hierarchy/outfit/job/redsoldier/scout/equip()
-	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/ammo_box/flares = 1 , /obj/item/torch/self_lit = 1)
-	..()
 
 /decl/hierarchy/outfit/job/kroot
 	uniform = /obj/item/clothing/under/rank/kroot
@@ -504,6 +393,8 @@ Begin Warhammer loadouts
 	id_slot = null
 	pda_slot = null
 	backpack_contents = list(/obj/item/reagent_containers/food/snacks/warfare/rat = 1,)
+
+/// TROOPER REGIMENT SELECTION
 
 /mob/living/carbon/human/proc/regimentselection()
 	set name = "Select your regiment"
@@ -625,6 +516,131 @@ Begin Warhammer loadouts
 
 			W.icon_state = "tagred"
 			W.assignment = "Valhallan"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+/// SERGEANT REGIMENT SELECTION
+
+/mob/living/carbon/human/proc/sergeantselection()
+	set name = "Select your regiment"
+	set category = "Regimental Sergeant Position"
+	set desc = "Choose your regiment"
+	if(!ishuman(src))
+		to_chat(src, "<span class='notice'>How tf are you seeing this, ping Wel Ard immediately</span>")
+		return
+	if(src.stat == DEAD)
+		to_chat(src, "<span class='notice'>You can't choose a class when you're dead.</span>")
+		return
+	var/mob/living/carbon/human/U = src
+	var/chapter = list("Cadian", "Krieger", "Catachan", "Valhallan") //lists all possible chapters
+	var/chapterchoice = input("Choose your regiment", "Available regiments") as anything in chapter
+
+	switch(chapterchoice)
+		if("Krieger")
+			var/troopnum = rand(1,50000)
+			src.name = "Troop [troopnum]"
+			src.real_name = "Troop [troopnum]"
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/krieger, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/mask/gas/krieg, slot_wear_mask)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/krieghelmet, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/krieg, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/shovel, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(
+			/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Krieg Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+		if("Cadian")
+			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Cadian Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+
+		if("Catachan")
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/device/flashlight/lantern, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Catachan Sergeant"
+			W.registered_name = real_name
+			W.update_label()
+			equip_to_slot_or_del(W, slot_wear_id)
+		if("Valhallan")
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/lascarbine, slot_l_hand)
+			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
+			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
+			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
+			equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/combat/warfare, slot_gloves)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/cell/lasgun, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/reagent_containers/food/snacks/warfare/rat, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones2, slot_in_backpack)
+			equip_to_slot_or_del(new /obj/item/stack/thrones3/five, slot_in_backpack)
+			U.verbs -= list(/mob/living/carbon/human/proc/sergeantselection,)
+
+			var/obj/item/card/id/dog_tag/guardsman/W = new
+
+			W.icon_state = "tagred"
+			W.assignment = "Valhallan Sergeant"
 			W.registered_name = real_name
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)

--- a/maps/warhammer/jobs/guardsmen.dm
+++ b/maps/warhammer/jobs/guardsmen.dm
@@ -258,8 +258,8 @@ Begin Warhammer loadouts
 /decl/hierarchy/outfit/job/ig/sergeant
 	name = OUTFIT_JOB_NAME("Imperial Guard Sergeant")
 	neck = /obj/item/reagent_containers/food/drinks/canteen
-	uniform = /obj/item/clothing/under/color/brown
-	suit = /obj/item/clothing/suit/armor/sgt
+	uniform = /obj/item/clothing/under/cadian_uniform
+	suit = /obj/item/clothing/suit/armor/cadiansgt
 	glasses = /obj/item/clothing/glasses/sunglasses
 	suit_store = /obj/item/gun/projectile/automatic/stubber
 	head = /obj/item/clothing/head/helmet/guardhelmet
@@ -415,7 +415,7 @@ Begin Warhammer loadouts
 			var/troopnum = rand(1,50000)
 			src.name = "Troop [troopnum]"
 			src.real_name = "Troop [troopnum]"
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieg_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
 			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
@@ -444,7 +444,7 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Cadian")
-			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/cadian_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -470,7 +470,7 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Catachan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/catachan, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -495,7 +495,7 @@ Begin Warhammer loadouts
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)
 		if("Valhallan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/valhallan_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
@@ -541,9 +541,8 @@ Begin Warhammer loadouts
 			var/troopnum = rand(1,50000)
 			src.name = "Troop [troopnum]"
 			src.real_name = "Troop [troopnum]"
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/krieger, slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/krieg, slot_shoes)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieg_uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/kriegsgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/luscius, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/krieger, slot_back)
 			equip_to_slot_or_del(new /obj/item/clothing/mask/gas/krieg, slot_wear_mask)
@@ -569,11 +568,10 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Cadian")
-			equip_to_slot_or_del(new /obj/item/clothing/under/guard/uniform, slot_w_uniform)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/guardsman, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/under/cadian_uniform, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/cadiansgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet, slot_head)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
@@ -595,11 +593,10 @@ Begin Warhammer loadouts
 			equip_to_slot_or_del(W, slot_wear_id)
 
 		if("Catachan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/camo, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/casual_pants/catachan, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/guardhelmet/catachan, slot_head)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/CatachanVest, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/catachansgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/device/flashlight/lantern, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)
@@ -620,11 +617,10 @@ Begin Warhammer loadouts
 			W.update_label()
 			equip_to_slot_or_del(W, slot_wear_id)
 		if("Valhallan")
-			equip_to_slot_or_del(new /obj/item/clothing/under/rank/krieger, slot_w_uniform)
+			equip_to_slot_or_del(new /obj/item/clothing/under/rank/valhallan_uniform, slot_w_uniform)
 			equip_to_slot_or_del(new /obj/item/clothing/head/valushanka, slot_head)
-			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallanarmor, slot_wear_suit)
+			equip_to_slot_or_del(new /obj/item/clothing/suit/armor/valhallasgt, slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
-			equip_to_slot_or_del(new /obj/item/gun/energy/las/lasgun/lascarbine, slot_l_hand)
 			equip_to_slot_or_del(new /obj/item/storage/box/ifak, slot_l_store)
 			equip_to_slot_or_del(new /obj/item/melee/mercycs, slot_belt)
 			equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/warfare, slot_back)


### PR DESCRIPTION
!1 - Adding:
new Sergeant regimental loadout system, still need to be tested.
new set of placeholder sergeant clothing in several variant: Cadian, Valhalla, Krieg and Catachan with custom name and examination text.
renamed guardsmen uniform (Cadian, Krieg, Catachan) with better exam text, better name.
added Valhalla uniform (using krieg texture). (Might conflict with the other PR created by wisezombiekiller)

!2 - Change:
Changed Medicae's uniform to standard cadian guardsman uniform instead of doctor's uniform (Why?)

!3 - Replace:
Replaced Valhallan Lascarbine with Lasgun cause realism and LORE-FRIENDLY!