### PR TITLE
removes tree full tile opacity

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -7,7 +7,6 @@
 	alpha = 200
 	density = FALSE
 	layer = 1
-	mouse_opacity = 2
 	plane = ABOVE_HUMAN_PLANE
 	layer = ABOVE_HUMAN_LAYER
 	var/log_type //type of log


### PR DESCRIPTION
why do trees have mouse opacity at 2? that means they take over the entire tiles their sprite is in, this should make them easier to avoid since mouse_opacity at 1 only makes you click on it when you click sprite and not whole tile, although i dindt test so get fucked.