### PR TITLE
People should spawn with satchels now

### DIFF
--- a/maps/delta/outfits/guardsmen.dm
+++ b/maps/delta/outfits/guardsmen.dm
@@ -33,7 +33,7 @@ Begin Warhammer loadouts
 	id_type = /obj/item/card/id/dog_tag/guardsman
 	pda_slot = null
 
-	flags = OUTFIT_HAS_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
+	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
 
 /decl/hierarchy/outfit/job/guardsman/krieg
 	name = OUTFIT_JOB_NAME("Krieger Guardsman")
@@ -106,7 +106,7 @@ Begin Warhammer loadouts
 
 	pda_slot = null
 
-	flags = OUTFIT_HAS_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
+	flags = OUTFIT_NO_BACKPACK|OUTFIT_NO_SURVIVAL_GEAR
 
 /decl/hierarchy/outfit/job/sergeant
 	name = OUTFIT_JOB_NAME("Cadian Sergeant")


### PR DESCRIPTION
This solves certain characters spawning with backpacks instead of satchels on round start. What I hadn't realized was what the flags for outfits actually meant, and that `OUTFIT_HAS_BACKPACK` actually means whether or not it has _`BACKPACK_OVERRIDES`_, not an actual backpack assigned.