### PR TITLE
Hotkey mode is now automatically enabled after every use of the 'Say' Command

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,4 +1,5 @@
 /mob/living/silicon/say(var/message, var/sanitize = 1)
+	winset(src, null, "mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
 	return ..(sanitize ? sanitize(message) : message)
 
 /mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -9,10 +9,11 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
-	
+
 	if(typing_indicator)
 		qdel(typing_indicator)
 	usr.say(message)
+	winset(src, null, "mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true")
 
 /mob/verb/me_verb(message as text)
 	set name = "Me"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -202,7 +202,7 @@ macro "borghotkeymode"
 		command = "Invisimin"
 
 macro "macro"
-	elem 
+	elem "enable_hotkey_mode"
 		name = "Tab"
 		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
 	elem 
@@ -581,7 +581,7 @@ macro "hotkeymode"
 		command = "Invisimin"
 
 macro "borgmacro"
-	elem 
+	elem "enable_hotkey_mode_borg"
 		name = "Tab"
 		command = ".winset \"mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
 	elem 


### PR DESCRIPTION
While this solution achieves the desired effect of returning to hotkey mode after sending a message,
it does not allow for players to choose the behavior they prefer.

A future, more robust solution could delegate this behavior to a player menu,
as some players may wish to send multiple messages in a row without returning to hotkey mode each time.

ALSO: added ID tags to the relevant macros, even though they didn't allow for easier winset calls as I had hoped.
Maybe they'll be useful someday.