### PR TITLE
Late Party Edit

### DIFF
--- a/code/modules/mob/observer/lateparty.dm
+++ b/code/modules/mob/observer/lateparty.dm
@@ -5,10 +5,10 @@
 	set name = "Late Party"
 	set desc= "Join a randomized late party picked from a list!"
 
-	var/partydelay = 18000 //in deciseconds (30 min rn or 18000 deciseconds)
+	var/partydelay = 24000 //in deciseconds (40 min or 24000 deciseconds)
 
 	if(world.time < partydelay) //all this does is cause a delay so people can't suicide or observer and rush the base
-		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:30!")
+		to_chat(src, "It is too early for a late party! This will open when round duration reaches 0:40!")
 		return
 
 	if(GLOB.deployed == 1) //checks if a party has already been sent, can make this value higher if you wish to send more than one!
@@ -28,30 +28,23 @@
 
 	switch(GLOB.partygang)
 		if(1)
-			src.say("I'm joining the late party 1/6 deployed!") //just speaks to deadchat quickly so 1. people know its open and 2. lets them know the amount of slots left.
+			src.say("I'm joining the late party 1/3 deployed!") //just speaks to deadchat quickly so 1. people know its open and 2. lets them know the amount of slots left.
 		if(2)
-			src.say("I'm joining the late party 2/6 deployed!")
+			src.say("I'm joining the late party 2/3 deployed!")
+		
 		if(3)
-			src.say("I'm joining the late party 3/6 deployed!")
-		if(4)
-			src.say("I'm joining the late party 4/6 deployed!")
-		if(5)
-			src.say("I'm joining the late party 5/6 deployed!")
-		if(6)
-			src.say("I'm joining the late party 6/6 deployed! All slots are now filled!")
+			src.say("I'm joining the late party 3/3 deployed! All slots are now filled!")
 			GLOB.deployed++ //ensures that only 1 party can be sent
+		if(4)
+			src.say("I'm joining the late party 4/8 deployed! Admemes have opened another party!")
+		if(5)
+			src.say("I'm joining the late party 5/8 deployed!")
+		if(6)
+			src.say("I'm joining the late party 6/8 deployed!")
 		if(7)
-			src.say("I'm joining the late party 7/12 deployed! Admemes have opened another party!")
+			src.say("I'm joining the late party 7/8 deployed!")
 		if(8)
-			src.say("I'm joining the late party 8/12 deployed!")
-		if(9)
-			src.say("I'm joining the late party 9/12 deployed!")
-		if(10)
-			src.say("I'm joining the late party 10/12 deployed!")
-		if(11)
-			src.say("I'm joining the late party 11/12 deployed!")
-		if(12)
-			src.say("I'm joining the late party 12/12 deployed! All slots are now filled!")
+			src.say("I'm joining the late party 8/8 deployed! All slots are now filled!")
 			GLOB.deployed++ //ensures that only 1 party can be sent
 
 
@@ -67,13 +60,13 @@
 			//new_character.key = usr.key //puts ghost in body with new key
 		if("Orkz")
 			message_admins("[usr.key] has joined the late party: Orkz.", 0) //msgs jannies
-			to_chat(usr, "<span class='warning'><b><font size=3>It's been a long flight, go to your Ork tab and be sure to stretch!</b></font size=3>") //tells mob to do thing
+			to_chat(usr, "<span class='warning'><b><font size=3>Go to your Ork tab and be sure to stretch! You are a fearless killer, your kind are the terror and envy of the greatest warriors within the sector - you are the devourer of worlds and slayer of men - no blade nor bullet dare pierce your skin.</b></font size=3>") //tells mob to do thing
 			usr.loc = get_turf(locate("landmark*orkstart")) //where they spawning
 			var/mob/living/carbon/human/ork/new_character = new(usr.loc) // da mob
 			new_character.key = usr.key //puts ghost in body with new key
 		if("Tau")
 			message_admins("[usr.key] has joined the late party: Tau.", 0) //msgs jannies
-			to_chat(usr, "<span class='warning'><b><font size=3>It has been a long flight but we have landed in Imperial space. Follow the Aun's orders. Assimilate this planet for the greater good! Check the Tau tab and remember your caste!</b></font size=3>") //tells mob to do thing
+			to_chat(usr, "<span class='warning'><b><font size=3>Check the Tau tab and remember your caste! It is up to you and your Squad to determine your mission here - remain loyal to eachother and remember the Doctrine Tactica. Plan and prepare for every possibility, and you will never act. It is nobler to have courage as we stumble into half the things we fear than to analyze every possible obstacle and begin nothing.</b></font size=3>") //tells mob to do thing
 			usr.loc = get_turf(locate("landmark*taustart")) //where they spawning
 			var/mob/living/carbon/human/tau/new_character = new(usr.loc)// da mob
 			new_character.key = usr.key //puts ghost in body with new key


### PR DESCRIPTION
This has been tested and functions with the current server build.

The intention of the update is to discourage people using the lateparty to murderbone everyone on lowpop when admins aren't around - with only 3 slots to start with they won't have infinite respawns to constantly attack the outpost. 

If admins are on the server they can easily turn it into a giant Xenos murder fest at their own discretion. We just want such incredible violence to be an intentional decision from now on and not accidental.

Hopefully this can get changed in future with the addition of gamemodes.

[Changelog]
First Xenos Wave adds 3 lateparty slots.

Second Xenos Wave adds 5 lateparty slots. If the lateparty is enabled a third time by an admin respawns are set to be infinite.

Timer is set to 40 minutes instead of 30 - every minute counts for the Protagonists when setting up defenses and waiting for new players to join.

Spawn Text for Ork and Tau were updated to encourage them to think of their roles as more then just Xenos Memes. 